### PR TITLE
Fixing bad variable reference

### DIFF
--- a/components/tabs/mdc-tab-bar.vue
+++ b/components/tabs/mdc-tab-bar.vue
@@ -60,7 +60,7 @@ export default {
       getOffsetWidthForIndicator: () =>
         this.$refs.indicator.offsetWidth,
       notifyChange: (evtData) => {
-        this.$emit('change', evtData.activeIndex)
+        this.$emit('change', evtData.activeTabIndex)
       },
       getNumberOfTabs: () =>
         this.tabs.length,


### PR DESCRIPTION
Fixing a reference to a property 'activeIndex' which should have been 'activeTabIndex' in the mdc-tab-bar component (which prevents you from actually knowing which tab was activated)